### PR TITLE
Improve TourFinder and HomeFinder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 **1.0.10-dev**
 
+- Changed `ActivityTourFinder` and `ActivityHomeFinder`to not only check for a single activity type, but now a list of activity types can be provided through the `activityTypes` parameter
+- Added `HomeTourFinder` which determines tours by using the location from the home finder
+- Added `HomeFinder` as a general component that can be bound in `AbstractDiscreteModeChoiceExtension`
 - `MATSimTripCandidate` was removed because now all `TripCandidate`s provide the trip duration
 - Make delay accumulation optional through `accumulateEstimationDelays`
 - BC: Improve time calculation and propagation of delays during estimation

--- a/docs/components/Constraint.md
+++ b/docs/components/Constraint.md
@@ -96,11 +96,7 @@ No special configuration.
 
 ## VehicleContinuity (Tour)
 
-*Description:* The `VehicleTourConstraint` makes sure that agents have consistent mode chains in their plans. There are three slots that enforce the behaviour. The option `restrictedModes` contains a list of modes that can only be used if the respective vehicle has been moved to the new departure location before. Also it is required that the vehicle can only start at and must be brought back to a specified home location.
-
-The *home location* of an agent is not given per se, so it needs to be inferred. Currently, `homeType` can be set either to `USE_FIRST_ACTIVITY`, which declares the location of the first activity in a tour as the "home location". This makes most sense if a plan-based model is used, where the tour in question is, in fact, the whole plan. Also, this setting resembles the behaviour of `SubtourModeChoice`. Alternatively, `USE_ACTIVITY_TYPE` can be chosen, which will search for the first activity of type `homeActivityType` in the tour and declare the location of that activity type as "home location".
-
-In some cases it may be possible that no "home location" can be found for an agent (e.g. if it is through-traffic entering and exiting the simulation scenario at two points). In that case, the modes needs to start at the first activity in the plan and end at the last one.
+*Description:* The `VehicleTourConstraint` makes sure that agents have consistent mode chains in their plans. There are three slots that enforce the behaviour. The option `restrictedModes` contains a list of modes that can only be used if the respective vehicle has been moved to the new departure location before. Also it is required that the vehicle can only start at and must be brought back to a specified home location. The *home location* of an agent is not given per se, so it needs to be inferred. For that, see the `HomeFinder` component that can be configured independently.
 
 *Level:* Tour
 
@@ -108,10 +104,6 @@ In some cases it may be possible that no "home location" can be found for an age
 
 ```xml
 <parameterset type="tourConstraint:VehicleContinuity" >
-	<!-- If USE_ACTIVITY_TYPE is chosen for homeType, this option defines which activity type to look for. -->
-	<param name="homeActivityType" value="home" />
-	<!-- Defines how to determine where the home of an agent is. -->
-	<param name="homeType" value="USE_FIRST_ACTIVITY" />
 	<!-- Defines which modes must fulfill continuity constraints (can only be used where they have been brough to before) -->
 	<param name="restrictedModes" value="car" />
 </parameterset>

--- a/docs/components/HomeFinder.md
+++ b/docs/components/HomeFinder.md
@@ -1,0 +1,34 @@
+# Home finders
+
+Home finders are not 100% necessary to set up a choice model, but they can be very helpful. For instance, the `VehicleContinuity` constraints make use of the home finde to determine where vehicles need to be brought back. Furthermore, the home finder can be used to segment a plan into tours.
+
+The DMC extension contains a number of predefined home finders, but it is also possible to write custom ones. How to do that is explained in [Customizing the model](docs/Customizing.md).
+
+In the following the existing built-in home finders are described. While some of them have additional configuration options that can be defined in a `parameterset`, some don't. In any case, the tour finder can be chosen in the main config group:
+
+```xml
+<module name="DiscreteModeChoice">
+	<!-- Defines which HomeFinder component to use. Built-in choices: ... -->
+	<param name="homeFinder" value="" />
+</module>
+```
+
+## ActivityBased
+
+*Description:* This home finder searches for the first occurence of an activity with one of the provided types and saves its location as the home location of the agent.
+
+*Configuration:*
+
+```xml
+<parameterset type="homeFinder:ActivityBased" >
+	<!-- Comma-separated activity types which should be considered as home. -->
+	<param name="activityTypes" value="home" />
+</parameterset>
+```
+
+## FirstActivity
+
+*Description:* The `FirstActivity` home finder looks up the location of the first activity in the plan and saves it as the home location of the agent.
+
+*Configuration:*
+No specific configuration available.

--- a/docs/components/TourFinder.md
+++ b/docs/components/TourFinder.md
@@ -15,14 +15,14 @@ In the following the existing built-in tour finders are described. While some of
 
 ## ActivityBased
 
-*Description:* This tour finder divides a plan depending on a specific activity type. For instance, if "home" is chosen, home-based tours will be considered, i.e. each chain of trips starting and ending at a "home" activity is a tour.
+*Description:* This tour finder divides a plan depending on specific activity types. For instance, if "home" is chosen, home-based tours will be considered, i.e. each chain of trips starting and ending at a "home" activity is a tour.
 
 *Configuration:*
 
 ```xml
 <parameterset type="tourFinder:ActivityBased" >
-	<!-- Activity type which should be considered as start and end of a tour. If a plan does not start or end with such an activity additional tours are added. -->
-	<param name="activityType" value="home" />
+	<!-- Comma-separated list of activity types which should be considered as start and end of a tour. If a plan does not start or end with such an activity additional tours are added. -->
+	<param name="activityTypes" value="home" />
 </parameterset>
 ```
 
@@ -32,3 +32,11 @@ In the following the existing built-in tour finders are described. While some of
 
 *Configuration:*
 No specific configuration available.
+
+## HomeBased
+
+*Description:* The `HomeBased` tour finder makes use of the `HomeFinder` component. Depending on which location is defined as the agent's home location by the `HomeFinder`, tours will be cut at this location.
+
+*Configuration:*
+No specific configuration available.
+

--- a/src/main/java/ch/ethz/matsim/discrete_mode_choice/components/tour_finder/AbstractTourFinder.java
+++ b/src/main/java/ch/ethz/matsim/discrete_mode_choice/components/tour_finder/AbstractTourFinder.java
@@ -1,0 +1,45 @@
+package ch.ethz.matsim.discrete_mode_choice.components.tour_finder;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+import org.matsim.api.core.v01.population.Activity;
+
+import ch.ethz.matsim.discrete_mode_choice.model.DiscreteModeChoiceTrip;
+
+public abstract class AbstractTourFinder implements TourFinder {
+	abstract protected Set<Activity> findActivities(List<DiscreteModeChoiceTrip> trips);
+
+	@Override
+	public List<List<DiscreteModeChoiceTrip>> findTours(List<DiscreteModeChoiceTrip> trips) {
+		Set<Activity> relevantActivities = findActivities(trips);
+
+		int currentIndex = 0;
+
+		List<List<DiscreteModeChoiceTrip>> tours = new LinkedList<>();
+		List<DiscreteModeChoiceTrip> currentTour = new LinkedList<>();
+
+		for (DiscreteModeChoiceTrip trip : trips) {
+			currentTour.add(trip);
+
+			if (relevantActivities.contains(trip.getDestinationActivity())) {
+				tours.add(new ArrayList<>(currentTour));
+				currentTour.clear();
+			}
+		}
+
+		if (currentTour.size() > 0) {
+			tours.add(currentTour);
+		}
+
+		int count = tours.stream().mapToInt(Collection::size).sum();
+		if (count != trips.size()) {
+			throw new IllegalStateException("Error while finding tours. This should never happen.");
+		}
+
+		return tours;
+	}
+}

--- a/src/main/java/ch/ethz/matsim/discrete_mode_choice/components/tour_finder/ActivityTourFinder.java
+++ b/src/main/java/ch/ethz/matsim/discrete_mode_choice/components/tour_finder/ActivityTourFinder.java
@@ -1,12 +1,11 @@
 package ch.ethz.matsim.discrete_mode_choice.components.tour_finder;
 
-import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Collection;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
+
+import org.matsim.api.core.v01.population.Activity;
 
 import ch.ethz.matsim.discrete_mode_choice.model.DiscreteModeChoiceTrip;
 
@@ -16,52 +15,44 @@ import ch.ethz.matsim.discrete_mode_choice.model.DiscreteModeChoiceTrip;
  * 
  * @author sebhoerl
  */
-public class ActivityTourFinder implements TourFinder {
-	private final String activityType;
+public class ActivityTourFinder extends AbstractTourFinder {
+	private final Collection<String> activityTypes;
+	private final String singleActivityType;
 
 	/**
 	 * Defines which activity type is used to establish tours.
 	 */
-	public ActivityTourFinder(String activityType) {
-		this.activityType = activityType;
+	public ActivityTourFinder(Collection<String> activityTypes) {
+		this.activityTypes = activityTypes;
+		this.singleActivityType = activityTypes.size() == 1 ? activityTypes.iterator().next() : null;
 	}
 
 	@Override
-	public List<List<DiscreteModeChoiceTrip>> findTours(List<DiscreteModeChoiceTrip> trips) {
-		Set<Integer> relevantActivityIndices = new HashSet<>();
+	protected Set<Activity> findActivities(List<DiscreteModeChoiceTrip> trips) {
+		Set<Activity> relevantActivities = new HashSet<>();
 
 		for (int index = 0; index < trips.size(); index++) {
 			DiscreteModeChoiceTrip trip = trips.get(index);
 
-			if (trip.getOriginActivity().getType().equals(activityType)) {
-				relevantActivityIndices.add(index);
+			if (singleActivityType == null) {
+				if (activityTypes.contains(trip.getOriginActivity().getType())) {
+					relevantActivities.add(trip.getOriginActivity());
+				}
+
+				if (activityTypes.contains(trip.getDestinationActivity().getType())) {
+					relevantActivities.add(trip.getDestinationActivity());
+				}
+			} else {
+				if (trip.getOriginActivity().getType().equals(singleActivityType)) {
+					relevantActivities.add(trip.getOriginActivity());
+				}
+
+				if (trip.getDestinationActivity().getType().equals(singleActivityType)) {
+					relevantActivities.add(trip.getDestinationActivity());
+				}
 			}
-
-			if (trip.getDestinationActivity().getType().equals(activityType)) {
-				relevantActivityIndices.add(index + 1);
-			}
 		}
 
-		List<Integer> orderedActivityIndices = new ArrayList<>(relevantActivityIndices);
-		Collections.sort(orderedActivityIndices);
-
-		List<List<DiscreteModeChoiceTrip>> tours = new LinkedList<>();
-
-		int currentActivityIndex = 0;
-
-		while (orderedActivityIndices.size() > 0) {
-			int nextActivityIndex = orderedActivityIndices.remove(0);
-
-			tours.add(trips.subList(currentActivityIndex, nextActivityIndex));
-			currentActivityIndex = nextActivityIndex;
-		}
-
-		if (currentActivityIndex != trips.size()) {
-			tours.add(trips.subList(currentActivityIndex, trips.size()));
-		}
-
-		tours = tours.stream().filter(t -> t.size() > 0).collect(Collectors.toList());
-
-		return tours;
+		return relevantActivities;
 	}
 }

--- a/src/main/java/ch/ethz/matsim/discrete_mode_choice/components/tour_finder/HomeTourFinder.java
+++ b/src/main/java/ch/ethz/matsim/discrete_mode_choice/components/tour_finder/HomeTourFinder.java
@@ -1,0 +1,46 @@
+package ch.ethz.matsim.discrete_mode_choice.components.tour_finder;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.matsim.api.core.v01.BasicLocation;
+import org.matsim.api.core.v01.Id;
+import org.matsim.api.core.v01.population.Activity;
+
+import ch.ethz.matsim.discrete_mode_choice.components.utils.LocationUtils;
+import ch.ethz.matsim.discrete_mode_choice.components.utils.home_finder.HomeFinder;
+import ch.ethz.matsim.discrete_mode_choice.model.DiscreteModeChoiceTrip;
+
+/**
+ * This TourFinder makes use of the HomeFinder that is defined in configuration.
+ * Tours will start and end at activities that are identified as home.
+ * 
+ * @author shoerl
+ */
+public class HomeTourFinder extends AbstractTourFinder {
+	private final HomeFinder homeFinder;
+
+	public HomeTourFinder(HomeFinder homeFinder) {
+		this.homeFinder = homeFinder;
+	}
+
+	@Override
+	protected Set<Activity> findActivities(List<DiscreteModeChoiceTrip> trips) {
+		Set<Activity> relevantActivities = new HashSet<>();
+
+		Id<? extends BasicLocation> homeLocationId = homeFinder.getHomeLocationId(trips);
+
+		for (DiscreteModeChoiceTrip trip : trips) {
+			if (LocationUtils.getLocationId(trip.getDestinationActivity()).equals(homeLocationId)) {
+				relevantActivities.add(trip.getDestinationActivity());
+			}
+
+			if (LocationUtils.getLocationId(trip.getDestinationActivity()).equals(homeLocationId)) {
+				relevantActivities.add(trip.getDestinationActivity());
+			}
+		}
+
+		return relevantActivities;
+	}
+}

--- a/src/main/java/ch/ethz/matsim/discrete_mode_choice/components/utils/home_finder/ActivityTypeHomeFinder.java
+++ b/src/main/java/ch/ethz/matsim/discrete_mode_choice/components/utils/home_finder/ActivityTypeHomeFinder.java
@@ -1,5 +1,6 @@
 package ch.ethz.matsim.discrete_mode_choice.components.utils.home_finder;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.matsim.api.core.v01.BasicLocation;
@@ -17,21 +18,33 @@ import ch.ethz.matsim.discrete_mode_choice.model.DiscreteModeChoiceTrip;
  * @author sebhoerl
  */
 public class ActivityTypeHomeFinder implements HomeFinder {
-	private final String activityType;
+	private final Collection<String> activityTypes;
+	private final String singleActivityType;
 
-	public ActivityTypeHomeFinder(String activityType) {
-		this.activityType = activityType;
+	public ActivityTypeHomeFinder(Collection<String> activityTypes) {
+		this.activityTypes = activityTypes;
+		this.singleActivityType = activityTypes.size() == 1 ? activityTypes.iterator().next() : null;
 	}
 
 	@Override
 	public Id<? extends BasicLocation> getHomeLocationId(List<DiscreteModeChoiceTrip> trips) {
 		for (DiscreteModeChoiceTrip trip : trips) {
-			if (trip.getOriginActivity().getType().equals(activityType)) {
-				return LocationUtils.getLocationId(trip.getOriginActivity());
-			}
+			if (singleActivityType == null) {
+				if (activityTypes.contains(trip.getOriginActivity().getType())) {
+					return LocationUtils.getLocationId(trip.getOriginActivity());
+				}
 
-			if (trip.getDestinationActivity().getType().equals(activityType)) {
-				return LocationUtils.getLocationId(trip.getDestinationActivity());
+				if (activityTypes.contains(trip.getDestinationActivity().getType())) {
+					return LocationUtils.getLocationId(trip.getDestinationActivity());
+				}
+			} else {
+				if (trip.getOriginActivity().getType().equals(singleActivityType)) {
+					return LocationUtils.getLocationId(trip.getOriginActivity());
+				}
+
+				if (trip.getDestinationActivity().getType().equals(singleActivityType)) {
+					return LocationUtils.getLocationId(trip.getDestinationActivity());
+				}
 			}
 		}
 

--- a/src/main/java/ch/ethz/matsim/discrete_mode_choice/modules/AbstractDiscreteModeChoiceExtension.java
+++ b/src/main/java/ch/ethz/matsim/discrete_mode_choice/modules/AbstractDiscreteModeChoiceExtension.java
@@ -6,6 +6,7 @@ import com.google.inject.binder.LinkedBindingBuilder;
 import com.google.inject.multibindings.MapBinder;
 
 import ch.ethz.matsim.discrete_mode_choice.components.tour_finder.TourFinder;
+import ch.ethz.matsim.discrete_mode_choice.components.utils.home_finder.HomeFinder;
 import ch.ethz.matsim.discrete_mode_choice.model.mode_availability.ModeAvailability;
 import ch.ethz.matsim.discrete_mode_choice.model.tour_based.TourConstraintFactory;
 import ch.ethz.matsim.discrete_mode_choice.model.tour_based.TourEstimator;
@@ -33,6 +34,7 @@ public abstract class AbstractDiscreteModeChoiceExtension extends AbstractModule
 
 	protected MapBinder<String, ModeAvailability> modeAvailabilityBinder;
 	protected MapBinder<String, TourFinder> tourFinderBinder;
+	protected MapBinder<String, HomeFinder> homeFinderBinder;
 
 	protected MapBinder<String, TourFilter> tourFilterBinder;
 	protected MapBinder<String, TripFilter> tripFilterBinder;
@@ -52,6 +54,7 @@ public abstract class AbstractDiscreteModeChoiceExtension extends AbstractModule
 
 		modeAvailabilityBinder = MapBinder.newMapBinder(binder(), String.class, ModeAvailability.class);
 		tourFinderBinder = MapBinder.newMapBinder(binder(), String.class, TourFinder.class);
+		homeFinderBinder = MapBinder.newMapBinder(binder(), String.class, HomeFinder.class);
 
 		installExtension();
 	}
@@ -90,6 +93,10 @@ public abstract class AbstractDiscreteModeChoiceExtension extends AbstractModule
 
 	protected final LinkedBindingBuilder<TourFinder> bindTourFinder(String name) {
 		return tourFinderBinder.addBinding(name);
+	}
+
+	protected final LinkedBindingBuilder<HomeFinder> bindHomeFinder(String name) {
+		return homeFinderBinder.addBinding(name);
 	}
 
 	abstract protected void installExtension();

--- a/src/main/java/ch/ethz/matsim/discrete_mode_choice/modules/ConstraintModule.java
+++ b/src/main/java/ch/ethz/matsim/discrete_mode_choice/modules/ConstraintModule.java
@@ -12,7 +12,6 @@ import org.matsim.core.config.ConfigGroup;
 import com.google.inject.Provider;
 import com.google.inject.Provides;
 import com.google.inject.Singleton;
-import com.google.inject.name.Named;
 
 import ch.ethz.matsim.discrete_mode_choice.components.constraints.LinkAttributeConstraint;
 import ch.ethz.matsim.discrete_mode_choice.components.constraints.ShapeFileConstraint;
@@ -20,8 +19,6 @@ import ch.ethz.matsim.discrete_mode_choice.components.constraints.SubtourModeCon
 import ch.ethz.matsim.discrete_mode_choice.components.constraints.TransitWalkConstraint;
 import ch.ethz.matsim.discrete_mode_choice.components.constraints.VehicleTourConstraint;
 import ch.ethz.matsim.discrete_mode_choice.components.constraints.VehicleTripConstraint;
-import ch.ethz.matsim.discrete_mode_choice.components.utils.home_finder.ActivityTypeHomeFinder;
-import ch.ethz.matsim.discrete_mode_choice.components.utils.home_finder.FirstActivityHomeFinder;
 import ch.ethz.matsim.discrete_mode_choice.components.utils.home_finder.HomeFinder;
 import ch.ethz.matsim.discrete_mode_choice.model.constraints.CompositeTourConstraintFactory;
 import ch.ethz.matsim.discrete_mode_choice.model.constraints.CompositeTripConstraintFactory;
@@ -33,7 +30,6 @@ import ch.ethz.matsim.discrete_mode_choice.modules.config.LinkAttributeConstrain
 import ch.ethz.matsim.discrete_mode_choice.modules.config.ShapeFileConstraintConfigGroup;
 import ch.ethz.matsim.discrete_mode_choice.modules.config.SubtourModeConstraintConfigGroup;
 import ch.ethz.matsim.discrete_mode_choice.modules.config.VehicleTourConstraintConfigGroup;
-import ch.ethz.matsim.discrete_mode_choice.modules.config.VehicleTourConstraintConfigGroup.HomeType;
 import ch.ethz.matsim.discrete_mode_choice.modules.config.VehicleTripConstraintConfigGroup;
 
 /**
@@ -146,45 +142,18 @@ public class ConstraintModule extends AbstractDiscreteModeChoiceExtension {
 		return new ShapeFileConstraint.Factory(network, config.getConstrainedModes(), config.getRequirement(), url);
 	}
 
-	private HomeFinder getHomeFinder(HomeType homeType, String homeActivityType) {
-		switch (homeType) {
-		case USE_ACTIVITY_TYPE:
-			return new ActivityTypeHomeFinder(homeActivityType);
-		case USE_FIRST_ACTIVITY:
-			return new FirstActivityHomeFinder();
-		default:
-			throw new IllegalStateException();
-		}
-	}
-
-	@Provides
-	@Singleton
-	@Named("trip")
-	public HomeFinder provideTripHomeFinder(DiscreteModeChoiceConfigGroup dmcConfig) {
-		VehicleTripConstraintConfigGroup config = dmcConfig.getVehicleTripConstraintConfig();
-		return getHomeFinder(config.getHomeType(), config.getHomeActivityType());
-	}
-
 	@Provides
 	@Singleton
 	public VehicleTripConstraint.Factory provideVehicleTripConstraintFactory(DiscreteModeChoiceConfigGroup dmcConfig,
-			@Named("trip") HomeFinder homeFinder) {
+			HomeFinder homeFinder) {
 		VehicleTripConstraintConfigGroup config = dmcConfig.getVehicleTripConstraintConfig();
 		return new VehicleTripConstraint.Factory(config.getRestrictedModes(), config.getIsAdvanced(), homeFinder);
 	}
 
 	@Provides
 	@Singleton
-	@Named("tour")
-	public HomeFinder provideTourHomeFinder(DiscreteModeChoiceConfigGroup dmcConfig) {
-		VehicleTourConstraintConfigGroup config = dmcConfig.getVehicleTourConstraintConfig();
-		return getHomeFinder(config.getHomeType(), config.getHomeActivityType());
-	}
-
-	@Provides
-	@Singleton
 	public VehicleTourConstraint.Factory provideVehicleTourConstraintFactory(DiscreteModeChoiceConfigGroup dmcConfig,
-			@Named("tour") HomeFinder homeFinder) {
+			HomeFinder homeFinder) {
 		VehicleTourConstraintConfigGroup config = dmcConfig.getVehicleTourConstraintConfig();
 		return new VehicleTourConstraint.Factory(config.getRestrictedModes(), homeFinder);
 	}

--- a/src/main/java/ch/ethz/matsim/discrete_mode_choice/modules/HomeFinderModule.java
+++ b/src/main/java/ch/ethz/matsim/discrete_mode_choice/modules/HomeFinderModule.java
@@ -1,0 +1,61 @@
+package ch.ethz.matsim.discrete_mode_choice.modules;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+import com.google.inject.Provider;
+import com.google.inject.Provides;
+import com.google.inject.Singleton;
+
+import ch.ethz.matsim.discrete_mode_choice.components.utils.home_finder.ActivityTypeHomeFinder;
+import ch.ethz.matsim.discrete_mode_choice.components.utils.home_finder.FirstActivityHomeFinder;
+import ch.ethz.matsim.discrete_mode_choice.components.utils.home_finder.HomeFinder;
+import ch.ethz.matsim.discrete_mode_choice.modules.config.ActivityHomeFinderConfigGroup;
+import ch.ethz.matsim.discrete_mode_choice.modules.config.DiscreteModeChoiceConfigGroup;
+
+/**
+ * Internal module that manages all built-in HomeFinder implementations.
+ * 
+ * @author sebhoerl
+ *
+ */
+public class HomeFinderModule extends AbstractDiscreteModeChoiceExtension {
+	public static final String FIRST_ACTIVITY = "FirstActivity";
+	public static final String ACTIVITY_BASED = "ActivityBased";
+
+	public static final Collection<String> COMPONENTS = Arrays.asList(FIRST_ACTIVITY, ACTIVITY_BASED);
+
+	@Override
+	public void installExtension() {
+		bindHomeFinder(FIRST_ACTIVITY).to(FirstActivityHomeFinder.class);
+		bindHomeFinder(ACTIVITY_BASED).to(ActivityTypeHomeFinder.class);
+	}
+
+	@Provides
+	@Singleton
+	public FirstActivityHomeFinder provideFirstActivityHomeFinder() {
+		return new FirstActivityHomeFinder();
+	}
+
+	@Provides
+	@Singleton
+	public ActivityTypeHomeFinder provideActivityTypeHomeFinder(DiscreteModeChoiceConfigGroup dmcConfig) {
+		ActivityHomeFinderConfigGroup config = dmcConfig.getActivityHomeFinderConfigGroup();
+		return new ActivityTypeHomeFinder(config.getActivityTypes());
+	}
+
+	@Provides
+	@Singleton
+	public HomeFinder provideHomeFinder(DiscreteModeChoiceConfigGroup dmcConfig,
+			Map<String, Provider<HomeFinder>> components) {
+		Provider<HomeFinder> provider = components.get(dmcConfig.getHomeFinder());
+
+		if (provider != null) {
+			return provider.get();
+		} else {
+			throw new IllegalStateException(
+					String.format("There is no HomeFinder component called '%s',", dmcConfig.getHomeFinder()));
+		}
+	}
+}

--- a/src/main/java/ch/ethz/matsim/discrete_mode_choice/modules/ModelModule.java
+++ b/src/main/java/ch/ethz/matsim/discrete_mode_choice/modules/ModelModule.java
@@ -46,6 +46,7 @@ public class ModelModule extends AbstractModule {
 		install(new SelectorModule());
 		install(new ConstraintModule());
 		install(new FilterModule());
+		install(new HomeFinderModule());
 
 		bind(ModeChainGeneratorFactory.class).to(DefaultModeChainGenerator.Factory.class);
 	}

--- a/src/main/java/ch/ethz/matsim/discrete_mode_choice/modules/TourFinderModule.java
+++ b/src/main/java/ch/ethz/matsim/discrete_mode_choice/modules/TourFinderModule.java
@@ -9,8 +9,10 @@ import com.google.inject.Provides;
 import com.google.inject.Singleton;
 
 import ch.ethz.matsim.discrete_mode_choice.components.tour_finder.ActivityTourFinder;
+import ch.ethz.matsim.discrete_mode_choice.components.tour_finder.HomeTourFinder;
 import ch.ethz.matsim.discrete_mode_choice.components.tour_finder.PlanTourFinder;
 import ch.ethz.matsim.discrete_mode_choice.components.tour_finder.TourFinder;
+import ch.ethz.matsim.discrete_mode_choice.components.utils.home_finder.HomeFinder;
 import ch.ethz.matsim.discrete_mode_choice.modules.config.ActivityTourFinderConfigGroup;
 import ch.ethz.matsim.discrete_mode_choice.modules.config.DiscreteModeChoiceConfigGroup;
 
@@ -23,13 +25,15 @@ import ch.ethz.matsim.discrete_mode_choice.modules.config.DiscreteModeChoiceConf
 public class TourFinderModule extends AbstractDiscreteModeChoiceExtension {
 	public static final String PLAN_BASED = "PlanBased";
 	public static final String ACTIVITY_BASED = "ActivityBased";
+	public static final String HOME_BASED = "HomeBased";
 
-	public static final Collection<String> COMPONENTS = Arrays.asList(PLAN_BASED, ACTIVITY_BASED);
+	public static final Collection<String> COMPONENTS = Arrays.asList(PLAN_BASED, ACTIVITY_BASED, HOME_BASED);
 
 	@Override
 	public void installExtension() {
 		bindTourFinder(PLAN_BASED).to(PlanTourFinder.class);
 		bindTourFinder(ACTIVITY_BASED).to(ActivityTourFinder.class);
+		bindTourFinder(HOME_BASED).to(HomeTourFinder.class);
 	}
 
 	@Provides
@@ -42,7 +46,13 @@ public class TourFinderModule extends AbstractDiscreteModeChoiceExtension {
 	@Singleton
 	public ActivityTourFinder provideActivityBasedTourFinder(DiscreteModeChoiceConfigGroup dmcConfig) {
 		ActivityTourFinderConfigGroup config = dmcConfig.getActivityTourFinderConfigGroup();
-		return new ActivityTourFinder(config.getActivityType());
+		return new ActivityTourFinder(config.getActivityTypes());
+	}
+
+	@Provides
+	@Singleton
+	public HomeTourFinder provideHomeTourFinder(HomeFinder homeFinder) {
+		return new HomeTourFinder(homeFinder);
 	}
 
 	@Provides

--- a/src/main/java/ch/ethz/matsim/discrete_mode_choice/modules/config/ActivityHomeFinderConfigGroup.java
+++ b/src/main/java/ch/ethz/matsim/discrete_mode_choice/modules/config/ActivityHomeFinderConfigGroup.java
@@ -1,6 +1,5 @@
 package ch.ethz.matsim.discrete_mode_choice.modules.config;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -8,16 +7,16 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
- * Configuration for the ActivityTourFinder.
+ * Configuration for the ActivityHomeFinder.
  * 
  * @author sebhoerl
  */
-public class ActivityTourFinderConfigGroup extends ComponentConfigGroup {
+public class ActivityHomeFinderConfigGroup extends ComponentConfigGroup {
 	private Collection<String> activityTypes = Arrays.asList("home");
 
 	public static final String ACTIVITY_TYPES = "activityTypes";
 
-	public ActivityTourFinderConfigGroup(String componentType, String componentName) {
+	public ActivityHomeFinderConfigGroup(String componentType, String componentName) {
 		super(componentType, componentName);
 	}
 
@@ -25,8 +24,7 @@ public class ActivityTourFinderConfigGroup extends ComponentConfigGroup {
 	public Map<String, String> getComments() {
 		Map<String, String> comments = new HashMap<>();
 
-		comments.put(ACTIVITY_TYPES,
-				"Comma-separated activity types which should be considered as start and end of a tour. If a plan does not start or end with such an activity additional tours are added.");
+		comments.put(ACTIVITY_TYPES, "Comma-separated activity types which should be considered as home.");
 
 		return comments;
 	}

--- a/src/main/java/ch/ethz/matsim/discrete_mode_choice/modules/config/DiscreteModeChoiceConfigGroup.java
+++ b/src/main/java/ch/ethz/matsim/discrete_mode_choice/modules/config/DiscreteModeChoiceConfigGroup.java
@@ -19,6 +19,7 @@ import ch.ethz.matsim.discrete_mode_choice.modules.ConstraintModule;
 import ch.ethz.matsim.discrete_mode_choice.modules.DiscreteModeChoiceModule;
 import ch.ethz.matsim.discrete_mode_choice.modules.EstimatorModule;
 import ch.ethz.matsim.discrete_mode_choice.modules.FilterModule;
+import ch.ethz.matsim.discrete_mode_choice.modules.HomeFinderModule;
 import ch.ethz.matsim.discrete_mode_choice.modules.ModeAvailabilityModule;
 import ch.ethz.matsim.discrete_mode_choice.modules.ModelModule;
 import ch.ethz.matsim.discrete_mode_choice.modules.ModelModule.ModelType;
@@ -40,6 +41,7 @@ public class DiscreteModeChoiceConfigGroup extends ReflectiveConfigGroup {
 
 	private String modeAvailability = ModeAvailabilityModule.CAR;
 	private String tourFinder = TourFinderModule.ACTIVITY_BASED;
+	private String homeFinder = HomeFinderModule.ACTIVITY_BASED;
 	private String selector = SelectorModule.RANDOM;
 
 	private Collection<String> tourConstraints = new HashSet<>(Arrays.asList(ConstraintModule.VEHICLE_CONTINUITY));
@@ -64,6 +66,7 @@ public class DiscreteModeChoiceConfigGroup extends ReflectiveConfigGroup {
 
 	public static final String MODE_AVAILABILITY = "modeAvailability";
 	public static final String TOUR_FINDER = "tourFinder";
+	public static final String HOME_FINDER = "homeFinder";
 	public static final String SELECTOR = "selector";
 
 	public static final String TOUR_CONSTRAINTS = "tourConstraints";
@@ -155,6 +158,16 @@ public class DiscreteModeChoiceConfigGroup extends ReflectiveConfigGroup {
 	@StringGetter(TOUR_FINDER)
 	public String getTourFinder() {
 		return tourFinder;
+	}
+
+	@StringSetter(HOME_FINDER)
+	public void setHomeFinder(String homeFinder) {
+		this.homeFinder = homeFinder;
+	}
+
+	@StringGetter(HOME_FINDER)
+	public String getHomeFinder() {
+		return homeFinder;
 	}
 
 	@StringSetter(SELECTOR)
@@ -296,6 +309,8 @@ public class DiscreteModeChoiceConfigGroup extends ReflectiveConfigGroup {
 
 		registry.put(new Tuple<>(TOUR_FINDER, TourFinderModule.ACTIVITY_BASED), //
 				ActivityTourFinderConfigGroup::new);
+		registry.put(new Tuple<>(HOME_FINDER, HomeFinderModule.ACTIVITY_BASED), //
+				ActivityHomeFinderConfigGroup::new);
 		registry.put(new Tuple<>(MODE_AVAILABILITY, ModeAvailabilityModule.DEFAULT), //
 				ModeAvailabilityConfigGroup::new);
 		registry.put(new Tuple<>(MODE_AVAILABILITY, ModeAvailabilityModule.CAR), //
@@ -372,6 +387,10 @@ public class DiscreteModeChoiceConfigGroup extends ReflectiveConfigGroup {
 		return (ActivityTourFinderConfigGroup) getComponentConfig(TOUR_FINDER, TourFinderModule.ACTIVITY_BASED);
 	}
 
+	public ActivityHomeFinderConfigGroup getActivityHomeFinderConfigGroup() {
+		return (ActivityHomeFinderConfigGroup) getComponentConfig(HOME_FINDER, HomeFinderModule.ACTIVITY_BASED);
+	}
+
 	public ModeAvailabilityConfigGroup getDefaultModeAvailabilityConfig() {
 		return (ModeAvailabilityConfigGroup) getComponentConfig(MODE_AVAILABILITY, ModeAvailabilityModule.DEFAULT);
 	}
@@ -437,6 +456,8 @@ public class DiscreteModeChoiceConfigGroup extends ReflectiveConfigGroup {
 				+ String.join(", ", ModeAvailabilityModule.COMPONENTS));
 		comments.put(TOUR_FINDER, "Defines which TourFinder component to use. Built-in choices: "
 				+ String.join(", ", TourFinderModule.COMPONENTS));
+		comments.put(HOME_FINDER, "Defines how home activities are identified. Built-in choices: "
+				+ String.join(", ", HomeFinderModule.COMPONENTS));
 		comments.put(SELECTOR, "Defines which Selector component to use. Built-in choices: "
 				+ String.join(", ", SelectorModule.COMPONENTS));
 		comments.put(TOUR_CONSTRAINTS,

--- a/src/main/java/ch/ethz/matsim/discrete_mode_choice/modules/config/VehicleTourConstraintConfigGroup.java
+++ b/src/main/java/ch/ethz/matsim/discrete_mode_choice/modules/config/VehicleTourConstraintConfigGroup.java
@@ -15,16 +15,8 @@ import java.util.stream.Collectors;
  */
 public class VehicleTourConstraintConfigGroup extends ComponentConfigGroup {
 	private Collection<String> restrictedModes = new HashSet<>(Arrays.asList("car", "bike"));
-	private HomeType homeType = HomeType.USE_FIRST_ACTIVITY;
-	private String homeActivityType = "home";
 
 	private static final String RESTRICTED_MODES = "restrictedModes";
-	private static final String HOME_TYPE = "homeType";
-	private static final String HOME_ACTIVITY_TYPE = "homeActivityType";
-
-	public enum HomeType {
-		USE_FIRST_ACTIVITY, USE_ACTIVITY_TYPE
-	}
 
 	public VehicleTourConstraintConfigGroup(String componentType, String componentName) {
 		super(componentType, componentName);
@@ -36,13 +28,6 @@ public class VehicleTourConstraintConfigGroup extends ComponentConfigGroup {
 
 		comments.put(RESTRICTED_MODES,
 				"Defines which modes must fulfill continuity constraints (can only be used where they have been brough to before)");
-
-		String options = Arrays.asList(HomeType.values()).stream().map(String::valueOf)
-				.collect(Collectors.joining(", "));
-		comments.put(HOME_TYPE, "Defines how to determine where the home of an agent is: " + options);
-
-		comments.put(HOME_ACTIVITY_TYPE,
-				"If USE_ACTIVITY_TYPE is chosen for homeType, this option defines which activity type to look for.");
 
 		return comments;
 	}
@@ -64,25 +49,5 @@ public class VehicleTourConstraintConfigGroup extends ComponentConfigGroup {
 	@StringGetter(RESTRICTED_MODES)
 	public String getRestrictedModesAsString() {
 		return String.join(", ", restrictedModes);
-	}
-
-	@StringGetter(HOME_ACTIVITY_TYPE)
-	public String getHomeActivityType() {
-		return homeActivityType;
-	}
-
-	@StringSetter(HOME_ACTIVITY_TYPE)
-	public void setHomeActivityType(String homeActivityType) {
-		this.homeActivityType = homeActivityType;
-	}
-
-	@StringGetter(HOME_TYPE)
-	public HomeType getHomeType() {
-		return homeType;
-	}
-
-	@StringSetter(HOME_TYPE)
-	public void setHomeType(HomeType homeType) {
-		this.homeType = homeType;
 	}
 }

--- a/src/main/java/ch/ethz/matsim/discrete_mode_choice/modules/config/VehicleTripConstraintConfigGroup.java
+++ b/src/main/java/ch/ethz/matsim/discrete_mode_choice/modules/config/VehicleTripConstraintConfigGroup.java
@@ -7,8 +7,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import ch.ethz.matsim.discrete_mode_choice.modules.config.VehicleTourConstraintConfigGroup.HomeType;
-
 /**
  * Config group for VehicleTripConstriant.
  * 
@@ -17,13 +15,9 @@ import ch.ethz.matsim.discrete_mode_choice.modules.config.VehicleTourConstraintC
  */
 public class VehicleTripConstraintConfigGroup extends ComponentConfigGroup {
 	private Collection<String> restrictedModes = new HashSet<>(Arrays.asList("car", "bike"));
-	private HomeType homeType = HomeType.USE_FIRST_ACTIVITY;
-	private String homeActivityType = "home";
 	private boolean isAdvanced = true;
 
 	private static final String RESTRICTED_MODES = "restrictedModes";
-	private static final String HOME_TYPE = "homeType";
-	private static final String HOME_ACTIVITY_TYPE = "homeActivityType";
 	private static final String IS_ADVANCED = "isAdvanced";
 
 	public VehicleTripConstraintConfigGroup(String componentType, String componentName) {
@@ -36,13 +30,6 @@ public class VehicleTripConstraintConfigGroup extends ComponentConfigGroup {
 
 		comments.put(RESTRICTED_MODES,
 				"Defines which modes must fulfill continuity constraints (can only be used where they have been brough to before)");
-
-		String options = Arrays.asList(HomeType.values()).stream().map(String::valueOf)
-				.collect(Collectors.joining(", "));
-		comments.put(HOME_TYPE, "Defines how to determine where the home of an agent is: " + options);
-
-		comments.put(HOME_ACTIVITY_TYPE,
-				"If USE_ACTIVITY_TYPE is chosen for homeType, this option defines which activity type to look for.");
 
 		comments.put(IS_ADVANCED, "Defines if the advanced constriant is used (vehicles must be brought back home).");
 
@@ -66,26 +53,6 @@ public class VehicleTripConstraintConfigGroup extends ComponentConfigGroup {
 	@StringGetter(RESTRICTED_MODES)
 	public String getRestrictedModesAsString() {
 		return String.join(", ", restrictedModes);
-	}
-
-	@StringGetter(HOME_ACTIVITY_TYPE)
-	public String getHomeActivityType() {
-		return homeActivityType;
-	}
-
-	@StringSetter(HOME_ACTIVITY_TYPE)
-	public void setHomeActivityType(String homeActivityType) {
-		this.homeActivityType = homeActivityType;
-	}
-
-	@StringGetter(HOME_TYPE)
-	public HomeType getHomeType() {
-		return homeType;
-	}
-
-	@StringSetter(HOME_TYPE)
-	public void setHomeType(HomeType homeType) {
-		this.homeType = homeType;
 	}
 
 	@StringGetter(IS_ADVANCED)

--- a/src/test/java/ch/ethz/matsim/discrete_mode_choice/components/tour_finder/ActivityTourFinderTest.java
+++ b/src/test/java/ch/ethz/matsim/discrete_mode_choice/components/tour_finder/ActivityTourFinderTest.java
@@ -2,6 +2,7 @@ package ch.ethz.matsim.discrete_mode_choice.components.tour_finder;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -41,7 +42,7 @@ public class ActivityTourFinderTest {
 
 	@Test
 	public void testActivityTourFinder() {
-		ActivityTourFinder finder = new ActivityTourFinder("home");
+		ActivityTourFinder finder = new ActivityTourFinder(Arrays.asList("home"));
 
 		List<DiscreteModeChoiceTrip> trips;
 		List<List<DiscreteModeChoiceTrip>> result;
@@ -73,6 +74,48 @@ public class ActivityTourFinderTest {
 		assertEquals(2, result.get(1).size());
 
 		trips = createFixture("home", "work", "home", "home", "work", "home");
+		result = finder.findTours(trips);
+		assertEquals(3, result.size());
+		assertEquals(5, result.stream().mapToInt(List::size).sum());
+		assertEquals(2, result.get(0).size());
+		assertEquals(1, result.get(1).size());
+		assertEquals(2, result.get(2).size());
+	}
+	
+	@Test
+	public void testActivityTourFinderMultiple() {
+		ActivityTourFinder finder = new ActivityTourFinder(Arrays.asList("home1", "home2", "home3", "home4"));
+
+		List<DiscreteModeChoiceTrip> trips;
+		List<List<DiscreteModeChoiceTrip>> result;
+
+		trips = createFixture("home1", "work", "home2");
+		result = finder.findTours(trips);
+		assertEquals(1, result.size());
+		assertEquals(2, result.stream().mapToInt(List::size).sum());
+
+		trips = createFixture("other", "home2", "work", "home1");
+		result = finder.findTours(trips);
+		assertEquals(2, result.size());
+		assertEquals(3, result.stream().mapToInt(List::size).sum());
+		assertEquals(1, result.get(0).size());
+		assertEquals(2, result.get(1).size());
+
+		trips = createFixture("home1", "work", "home2", "other");
+		result = finder.findTours(trips);
+		assertEquals(2, result.size());
+		assertEquals(3, result.stream().mapToInt(List::size).sum());
+		assertEquals(2, result.get(0).size());
+		assertEquals(1, result.get(1).size());
+
+		trips = createFixture("home1", "work", "shop", "home1", "other", "home3");
+		result = finder.findTours(trips);
+		assertEquals(2, result.size());
+		assertEquals(5, result.stream().mapToInt(List::size).sum());
+		assertEquals(3, result.get(0).size());
+		assertEquals(2, result.get(1).size());
+
+		trips = createFixture("home1", "work", "home2", "home3", "work", "home2");
 		result = finder.findTours(trips);
 		assertEquals(3, result.size());
 		assertEquals(5, result.stream().mapToInt(List::size).sum());

--- a/src/test/java/ch/ethz/matsim/discrete_mode_choice/replanning/TestDepartureTimes.java
+++ b/src/test/java/ch/ethz/matsim/discrete_mode_choice/replanning/TestDepartureTimes.java
@@ -203,7 +203,7 @@ public class TestDepartureTimes {
 		TourFilter tourFilter = new CompositeTourFilter(Collections.emptySet());
 		ModeAvailability modeAvailability = new DefaultModeAvailability(Arrays.asList("car"));
 		TourConstraintFactory constraintFactory = new CompositeTourConstraintFactory();
-		TourFinder tourFinder = new ActivityTourFinder("home");
+		TourFinder tourFinder = new ActivityTourFinder(Arrays.asList("home"));
 		UtilitySelectorFactory selectorFactory = new RandomSelector.Factory();
 		FallbackBehaviour fallbackBehaviour = FallbackBehaviour.EXCEPTION;
 		ModeChainGeneratorFactory modeChainGeneratorFactory = new DefaultModeChainGenerator.Factory();


### PR DESCRIPTION
- Makes `HomeFinder` a full component that can be bound.
- Considers now lists of `activityTypes` instead of only one specific one for `ActivityTypeTourFinder` and `ActivityTypeHomeFinder`.